### PR TITLE
build(deps): Refactor dependencies in libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,61 +4,85 @@
 #
 
 [versions]
+# Build Tools & Plugins
 agp = "9.0.1"
 kotlin = "2.3.10"
 ksp = "2.3.6"
 spotless = "8.2.1"
-navigation-compose = "2.9.7"
+
+# AndroidX
+androidx-appcompat = "1.7.1"
+androidx-browser = "1.9.0"
+androidx-core-ktx = "1.17.0"
+androidx-core-splashscreen = "1.2.0"
+androidx-datastore = "1.3.0-alpha06"
+androidx-lifecycle = "2.10.0"
+androidx-activity = "1.12.4"
+androidx-navigation = "2.9.7"
+androidx-room = "2.8.4"
+androidx-window = "1.5.1"
+androidx-test-ext-junit = "1.3.0"
+androidx-test-espresso = "3.7.0"
+androidx-arch-core-testing = "2.2.0"
+
+# Compose & Material 3
+androidx-compose-bom = "2026.02.01"
+androidx-m3-adaptive = "1.2.0"
+androidx-m3-adaptive-nav-suite = "1.4.0"
+androidx-tv-foundation = "1.0.0-alpha12"
+androidx-tv-material = "1.1.0-alpha01"
+
+# Third Party
+coil = "2.7.0"
+google-oss-licenses = "17.4.0"
+google-oss-licenses-plugin = "0.10.10"
+google-truth = "1.4.5"
+jakewharton-timber = "5.0.1"
+koin-bom = "4.1.1"
+kotlinx-coroutines = "1.10.2"
+kotlinx-serialization-json = "1.10.0"
+junit = "4.13.2"
+mockito-kotlin = "6.2.3"
+mockk = "1.14.9"
 
 [libraries]
-# implementation
-androidx-appcompat = "androidx.appcompat:appcompat:1.7.1"
-androidx-browser = "androidx.browser:browser:1.9.0"
-androidx-core-ktx = "androidx.core:core-ktx:1.17.0"
-androidx-core-splashscreen = "androidx.core:core-splashscreen:1.2.0"
-androidx-datastore-preferences = "androidx.datastore:datastore-preferences:1.3.0-alpha06"
-androidx-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.10.0"
-androidx-lifecycle-runtime-compose = "androidx.lifecycle:lifecycle-runtime-compose:2.10.0"
-androidx-activity-compose = "androidx.activity:activity-compose:1.12.4"
-androidx-navigation-runtime-ktx = "androidx.navigation:navigation-runtime-ktx:2.9.7"
-androidx-room-compiler = "androidx.room:room-compiler:2.8.4"
-androidx-room-ktx = "androidx.room:room-ktx:2.8.4"
-androidx-room-runtime = "androidx.room:room-runtime:2.8.4"
-androidx-window = "androidx.window:window:1.5.1"
-androidx-window-core = "androidx.window:window-core:1.5.1"
-coil-compose = "io.coil-kt:coil-compose:2.7.0"
-google-oss-licenses = "com.google.android.gms:play-services-oss-licenses:17.4.0"
-google-oss-licenses-plugin = "com.google.android.gms:oss-licenses-plugin:0.10.10"
-kotlin-serialization-plugin = "org.jetbrains.kotlin:kotlin-serialization:2.3.10"
-kotlinx-coroutines-android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
-kotlinx-coroutines-core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
-kotlinx-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0"
-jakewharton-timber = "com.jakewharton.timber:timber:5.0.1"
+# AndroidX Core & Lifecycle
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidx-core-splashscreen" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 
-# koin-implementation-with-bom
-koin-bom = "io.insert-koin:koin-bom:4.1.1"
+# Room & Window
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
+androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
+androidx-window-core = { module = "androidx.window:window-core", version.ref = "androidx-window" }
+
+# Navigation
+androidx-navigation-runtime-ktx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "androidx-navigation" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
+
+# Kotlin & Coroutines
+kotlin-serialization-plugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+
+# Koin (BOM)
+koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin-bom" }
 koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose" }
 koin-androidx-compose-navigation = { module = "io.insert-koin:koin-androidx-compose-navigation" }
 
-# test-implementation
-junit = "junit:junit:4.13.2"
-kotlinx-coroutines-test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
-mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:6.2.3"
-mockk = "io.mockk:mockk:1.14.9"
-
-# android-test-implementation
-androidx-test-ext-junit = "androidx.test.ext:junit:1.3.0"
-androidx-test-espresso-core = "androidx.test.espresso:espresso-core:3.7.0"
-androidx-arch-core-testing = "androidx.arch.core:core-testing:2.2.0"
-coil-test = "io.coil-kt:coil-test:2.7.0"
-google-truth = "com.google.truth:truth:1.4.5"
-
-# androidx-compose-implementation-with-bom
-androidx-compose-bom = "androidx.compose:compose-bom:2026.02.00"
+# Compose (BOM)
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-material3-wsc = { module = "androidx.compose.material3:material3-window-size-class" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
@@ -66,21 +90,38 @@ androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 
-# implementation/material-adaptive
-androidx-m3-adaptive = "androidx.compose.material3.adaptive:adaptive:1.2.0"
-androidx-m3-adaptive-layout = "androidx.compose.material3.adaptive:adaptive-layout:1.2.0"
-androidx-m3-adaptive-navigation = "androidx.compose.material3.adaptive:adaptive-navigation:1.2.0"
-androidx-m3-adaptive-navigation-suite = "androidx.compose.material3:material3-adaptive-navigation-suite:1.4.0"
+# Material 3 Adaptive
+androidx-m3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidx-m3-adaptive" }
+androidx-m3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "androidx-m3-adaptive" }
+androidx-m3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "androidx-m3-adaptive" }
+androidx-m3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite", version.ref = "androidx-m3-adaptive-nav-suite" }
 
-# androidx-compose-tv-implementation
-androidx-tv-foundation = "androidx.tv:tv-foundation:1.0.0-alpha12"
-androidx-tv-material = "androidx.tv:tv-material:1.1.0-alpha01"
+# TV & Others
+androidx-tv-foundation = { module = "androidx.tv:tv-foundation", version.ref = "androidx-tv-foundation" }
+androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "androidx-tv-material" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+jakewharton-timber = { module = "com.jakewharton.timber:timber", version.ref = "jakewharton-timber" }
+google-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "google-oss-licenses" }
+google-oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "google-oss-licenses-plugin" }
 
-#[libraries] gradle convention plugin
-android-gradlePlugin = "com.android.tools.build:gradle:9.0.1"
-kotlin-gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.10"
-compose-compiler-gradlePlugin = "org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.10"
-spotless-gradlePlugin = "com.diffplug.spotless:spotless-plugin-gradle:8.2.1"
+# Unit Testing
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+# Android Testing
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
+androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core-testing" }
+coil-test = { module = "io.coil-kt:coil-test", version.ref = "coil" }
+google-truth = { module = "com.google.truth:truth", version.ref = "google-truth" }
+
+# Build Plugins Libraries (Convention Plugins)
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+compose-compiler-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+spotless-gradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -95,4 +136,5 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 [bundles]
 database-room = ["androidx-room-ktx", "androidx-room-runtime"]
 koin = ["koin-androidx-compose", "koin-androidx-compose-navigation"]
+lifecycle = ["androidx-lifecycle-runtime-ktx", "androidx-lifecycle-runtime-compose"]
 m3-adaptive = ["androidx-m3-adaptive", "androidx-m3-adaptive-layout", "androidx-m3-adaptive-navigation", "androidx-m3-adaptive-navigation-suite"]


### PR DESCRIPTION
Organize version catalog and use version refs

- Move all hardcoded versions to [versions] section.
- Standardize library definitions using { module, version.ref } syntax.
- Group dependencies by category and add new bundles.