### PR TITLE
build: refactor version catalog and optimize gradle performance flags

### DIFF
--- a/build-logic/convention/src/main/kotlin/dev/marlonlom/cappajv/extensions/AndroidKotlin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/marlonlom/cappajv/extensions/AndroidKotlin.kt
@@ -51,6 +51,7 @@ internal fun Project.configureAndroidKotlin(
 
       add("androidTestImplementation", versionCatalog().findLibrary("androidx-test-espresso-core").get())
       add("androidTestImplementation", versionCatalog().findLibrary("androidx-test-ext-junit").get())
+      add("androidTestImplementation", versionCatalog().findLibrary("androidx-arch-core-testing").get())
       add("androidTestImplementation", versionCatalog().findLibrary("google-truth").get())
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,11 +10,10 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -25,3 +24,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+kotlin.daemon.jvm.options=-Xmx2048m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,92 +4,129 @@
 #
 
 [versions]
+activityCompose = "1.13.0"
 agp = "9.2.1"
+appcompat = "1.7.1"
+archCoreTesting = "2.2.0"
+browser = "1.10.0"
+coil = "2.7.0"
+composeBom = "2026.05.00"
+coreKtx = "1.18.0"
+coreSplashscreen = "1.2.0"
+coroutines = "1.11.0"
+datastore = "1.3.0-alpha09"
+espresso = "3.7.0"
+googleTruth = "1.4.5"
+gradle = "9.2.1"
+junit = "4.13.2"
+junitExt = "1.3.0"
+koinBom = "4.2.1"
 kotlin = "2.3.21"
 ksp = "2.3.8"
+lifecycle = "2.10.0"
+m3Adaptive = "1.2.0"
+m3AdaptiveNavSuite = "1.4.0"
+mockitoKotlin = "6.3.0"
+mockk = "1.14.9"
+navigationCompose = "2.9.8"
+ossLicenses = "17.5.1"
+ossLicensesPlugin = "0.12.0"
+room = "2.8.4"
+serializationJson = "1.11.0"
 spotless = "8.5.1"
-navigation-compose = "2.9.8"
+timber = "5.0.1"
+tvFoundation = "1.0.0"
+tvMaterial = "1.1.0"
+window = "1.5.1"
 
 [libraries]
-# implementation
-androidx-appcompat = "androidx.appcompat:appcompat:1.7.1"
-androidx-browser = "androidx.browser:browser:1.10.0"
-androidx-core-ktx = "androidx.core:core-ktx:1.18.0"
-androidx-core-splashscreen = "androidx.core:core-splashscreen:1.2.0"
-androidx-datastore-preferences = "androidx.datastore:datastore-preferences:1.3.0-alpha09"
-androidx-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.10.0"
-androidx-lifecycle-runtime-compose = "androidx.lifecycle:lifecycle-runtime-compose:2.10.0"
-androidx-activity-compose = "androidx.activity:activity-compose:1.13.0"
-androidx-navigation-runtime-ktx = "androidx.navigation:navigation-runtime-ktx:2.9.8"
-androidx-room-compiler = "androidx.room:room-compiler:2.8.4"
-androidx-room-ktx = "androidx.room:room-ktx:2.8.4"
-androidx-room-runtime = "androidx.room:room-runtime:2.8.4"
-androidx-window = "androidx.window:window:1.5.1"
-androidx-window-core = "androidx.window:window-core:1.5.1"
-coil-compose = "io.coil-kt:coil-compose:2.7.0"
-google-oss-licenses = "com.google.android.gms:play-services-oss-licenses:17.5.1"
-google-oss-licenses-plugin = "com.google.android.gms:oss-licenses-plugin:0.12.0"
-kotlin-serialization-plugin = "org.jetbrains.kotlin:kotlin-serialization:2.3.21"
-kotlinx-coroutines-android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0"
-kotlinx-coroutines-core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0"
-kotlinx-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0"
-jakewharton-timber = "com.jakewharton.timber:timber:5.0.1"
+# Gradle Convention Plugins Dependencies
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+compose-compiler-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+spotless-gradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 
-# koin-implementation-with-bom
-koin-bom = "io.insert-koin:koin-bom:4.2.1"
-koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose" }
-koin-androidx-compose-navigation = { module = "io.insert-koin:koin-androidx-compose-navigation" }
+# AndroidX Main Dependencies
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-navigation-runtime-ktx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "navigationCompose" }
+androidx-window = { module = "androidx.window:window", version.ref = "window" }
+androidx-window-core = { module = "androidx.window:window-core", version.ref = "window" }
 
-# test-implementation
-junit = "junit:junit:4.13.2"
-kotlinx-coroutines-test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0"
-mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:6.3.0"
-mockk = "io.mockk:mockk:1.14.9"
-
-# android-test-implementation
-androidx-test-ext-junit = "androidx.test.ext:junit:1.3.0"
-androidx-test-espresso-core = "androidx.test.espresso:espresso-core:3.7.0"
-androidx-arch-core-testing = "androidx.arch.core:core-testing:2.2.0"
-coil-test = "io.coil-kt:coil-test:2.7.0"
-google-truth = "com.google.truth:truth:1.4.5"
-
-# androidx-compose-implementation-with-bom
-androidx-compose-bom = "androidx.compose:compose-bom:2026.05.00"
+# AndroidX Jetpack Compose (BOM Controlled)
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-material3-wsc = { module = "androidx.compose.material3:material3-window-size-class" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
-androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 
-# implementation/material-adaptive
-androidx-m3-adaptive = "androidx.compose.material3.adaptive:adaptive:1.2.0"
-androidx-m3-adaptive-layout = "androidx.compose.material3.adaptive:adaptive-layout:1.2.0"
-androidx-m3-adaptive-navigation = "androidx.compose.material3.adaptive:adaptive-navigation:1.2.0"
-androidx-m3-adaptive-navigation-suite = "androidx.compose.material3:material3-adaptive-navigation-suite:1.4.0"
+# AndroidX Material3 Adaptive Layouts
+androidx-m3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "m3Adaptive" }
+androidx-m3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "m3Adaptive" }
+androidx-m3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "m3Adaptive" }
+androidx-m3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite", version.ref = "m3AdaptiveNavSuite" }
 
-# androidx-compose-tv-implementation
-androidx-tv-foundation = "androidx.tv:tv-foundation:1.0.0"
-androidx-tv-material = "androidx.tv:tv-material:1.1.0"
+# AndroidX TV
+androidx-tv-foundation = { module = "androidx.tv:tv-foundation", version.ref = "tvFoundation" }
+androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "tvMaterial" }
 
-#[libraries] gradle convention plugin
-android-gradlePlugin = "com.android.tools.build:gradle:9.2.1"
-kotlin-gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.21"
-compose-compiler-gradlePlugin = "org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.21"
-spotless-gradlePlugin = "com.diffplug.spotless:spotless-plugin-gradle:8.5.1"
+# AndroidX Room Database
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+
+# Google OSS Licenses
+google-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "ossLicenses" }
+google-oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
+
+# Kotlin / KotlinX
+kotlin-serialization-plugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
+
+# Dependency Injection (Koin)
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose" }
+koin-androidx-compose-navigation = { module = "io.insert-koin:koin-androidx-compose-navigation" }
+koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koinBom" }
+
+# Image Loading & Logging
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+jakewharton-timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+
+# Local Unit Tests
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+# Instrumentation (Android) Tests
+androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "archCoreTesting" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "junitExt" }
+coil-test = { module = "io.coil-kt:coil-test", version.ref = "coil" }
+google-truth = { module = "com.google.truth:truth", version.ref = "googleTruth" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 google-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 
 [bundles]


### PR DESCRIPTION
## Pull request description
This PR addresses build logic maintainability and performance across the project by refactoring the Version Catalog, optimizing internal JVM/Gradle flags, and supplementing our shared Android testing conventions.

### Key Changes

#### 🛠️ Build & Performance (`gradle.properties`)
- Increased Gradle JVM max heap from `2048m` to `4096m` and set max metaspace to `1g`.
- Enabled `org.gradle.parallel`, `org.gradle.caching`, and `org.gradle.configuration-cache`.
- Configured Kotlin daemon limits explicitly (`-Xmx2048m`).

#### 📦 Dependency Management (`libs.versions.toml`)
- Migrated the version catalog completely away from basic string formats to structured map variants.
- Re-categorized dependencies neatly (e.g., *Gradle Convention Plugins*, *AndroidX Main*, *Jetpack Compose (BOM Controlled)*, *Instrumentation Tests*).

#### 🧪 Convention Plugins (`AndroidKotlin.kt`)
- Automatically bundle `androidx-arch-core-testing` into `androidTestImplementation` scopes alongside Espresso and JUnit via the `configureAndroidKotlin` project extension.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor / Performance tuning (non-breaking change codebase/build optimizations)

## How Has This Been Tested?
- [x] Executed local Gradle sync.
- [x] Ran clean builds to verify configuration cache hits: `./gradlew clean assembleDebug --configuration-cache`.
- [x] Verified test dependencies resolve correctly in instrumentation scopes.